### PR TITLE
Fix storybooks.io build issue

### DIFF
--- a/.storybook/static/CNAME
+++ b/.storybook/static/CNAME
@@ -1,0 +1,1 @@
+uikit-react.io

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "babel ./src --out-dir ./lib",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 9001",
-    "build-storybook": "node ./node_modules/.bin/build-storybook -o .out && echo \"uikit-react.io\" > .out/CNAME",
+    "build-storybook": "build-storybook -o .out -s .storybook/static",
     "deploy-storybook": "storybook-to-ghpages",
     "postpublish": "npm run deploy-storybook"
   },


### PR DESCRIPTION
Hi,
storybooks.io currently do not support multiple commands in "build-storybook" npm script. We're working on this issue. Until it's fixed, please use the static directory option to add the CNAME file.