### PR TITLE
Reafactor/allow css class in footer button and allow callbacks on handle close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+* Added two props, `confirmButtonClass` and `cancelButtonClass` to footer buttons that allows to pass CSS classes.
+* `handleClose` allows callbacks.
 
 ## [2.0.0] - 2016-11-22
 ### Bugfixes

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "babel-register": "6.18.0",
     "coveralls": "2.11.15",
     "css-loader": "0.26.1",
-    "eslint": "3.12.0",
+    "eslint": "3.12.1",
     "eslint-config-airbnb": "13.0.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "2.2.3",

--- a/src/Modal/Dialog.js
+++ b/src/Modal/Dialog.js
@@ -21,8 +21,8 @@ export default class Dialog extends Component
 
   handleOverlayClick = event => event.stopPropagation()
 
-  handleClose = () => {
-    this.props.handleClose()
+  handleClose = (callback) => {
+    this.props.handleClose(callback)
   }
 
   render() {

--- a/src/Modal/__tests__/index-test.js
+++ b/src/Modal/__tests__/index-test.js
@@ -163,6 +163,14 @@ describe('Modal', () => {
     expect(instance.state.isOpen).toBeFalsy()
   })
 
+  it('should handle callback function if handleClose has it', () => {
+    const instance = component.getInstance()
+    const callback = jest.fn()
+    instance.closePortal = jest.fn()
+    instance.handleClose(callback)
+    expect(instance.state.isOpen).toBeFalsy()
+  })
+
   it('should set modal ref to Portal', () => {
     const instance = component.getInstance()
     const node = { closePortal: jest.fn() }

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -10,8 +10,10 @@ export default class Modal extends Component {
 
   static propTypes = {
     target: PropTypes.element.isRequired,
+    cancelButtonClass: PropTypes.string,
     cancelLabel: PropTypes.string,
     children: PropTypes.node,
+    confirmButtonClass: PropTypes.string,
     confirmLabel: PropTypes.string,
     isOpen: PropTypes.bool,
     type: PropTypes.string,
@@ -106,14 +108,31 @@ export default class Modal extends Component {
 
     let footer = []
     if (type === 'alert') {
-      footer = [() => <Button primary onClick={handleConfirm}>{confirmLabel}</Button>]
+      footer = [
+        () =>
+          <Button
+            primary
+            className={this.props.confirmButtonClass}
+            onClick={handleConfirm}
+          >{confirmLabel}
+          </Button>,
+      ]
     }
 
     if (type === 'confirm' || type === 'prompt') {
       footer = [
-        () => <Button onClick={handleCancel}>{cancelLabel}</Button>,
+        () => <Button className={this.props.cancelButtonClass} onClick={handleCancel}>
+          {cancelLabel}
+        </Button>,
         () => <span>&nbsp;</span>,
-        () => <Button primary onClick={handleConfirm}>{confirmLabel}</Button>,
+        () =>
+          <Button
+            primary
+            className={this.props.confirmButtonClass}
+            onClick={handleConfirm}
+          >
+            {confirmLabel}
+          </Button>,
       ]
     }
     const { children, ...dialogProps } = this.props

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -48,12 +48,15 @@ export default class Modal extends Component {
     setTimeout(() => this.setState({ isOpen: true }), 0)
   }
 
-  handleClose = () => {
+  handleClose = (callback) => {
     this.setState(
       { isOpen: false },
       () => setTimeout(
         () => {
           this.modal.closePortal()
+          if (callback) {
+            callback()
+          }
         },
         300
       )

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -54,7 +54,7 @@ export default class Modal extends Component {
       () => setTimeout(
         () => {
           this.modal.closePortal()
-          if (callback) {
+          if (typeof callback === 'function') {
             callback()
           }
         },

--- a/src/stories/Modal.js
+++ b/src/stories/Modal.js
@@ -181,6 +181,9 @@ storiesOf('Modal', module)
   .addWithInfo('Confirm', '', () => (
     <div className="uk-margin-bottom">
       <Modal
+        cancelButtonClass="uk-button-primary"
+        confirmButtonClass="uk-button-danger"
+        confirmLabel="Delete"
         // eslint-disable-next-line react/prop-types,react/jsx-no-bind
         target={<Button>Confirm</Button>}
         type="confirm"


### PR DESCRIPTION
Following tasks are taken care of in this PR: 
- Footer allows passing buttons but we had `confirmLabel ` and `cancelLabel` props to change their label but no ways to pass CSS class to them. Added two props, `confirmButtonClass` and `cancelButtonClass` that allows to pass CSS class to these buttons. 
- Also, handleClose allows callbacks. 