### PR TITLE
Fix: Support SSR use cases

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -35,7 +35,7 @@ rules:
     - callbacksLast: true
       shorthandFirst: true
       ignoreCase: true
-  react/react-in-jsx-scope: off
+  react/react-in-jsx-scope: error
   react/jsx-filename-extension: off
   import/no-extraneous-dependencies: off
   global-require: off

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,11 +2,6 @@ const path = require('path')
 const webpack = require('webpack')
 
 module.exports = {
-  plugins: [
-    new webpack.ProvidePlugin({
-      React: 'react',
-    }),
-  ],
   module: {
     rules: [
       {

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import { Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 export default class Button extends Component {

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import Recact, { Component, cloneElement } from 'react'
+import React, { Component, cloneElement } from 'react'
 import PropTypes from 'prop-types'
 
 const links = {}

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import { Component, cloneElement } from 'react'
+import Recact, { Component, cloneElement } from 'react'
 import PropTypes from 'prop-types'
 
 const links = {}

--- a/src/Icon/Default.js
+++ b/src/Icon/Default.js
@@ -1,4 +1,4 @@
-import { PureComponent } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
 import cx from 'classnames'

--- a/src/Icon/Spinner.js
+++ b/src/Icon/Spinner.js
@@ -1,5 +1,4 @@
-import React from 'react'
-import { PureComponent } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import computedStyle from 'computed-style'

--- a/src/Icon/Spinner.js
+++ b/src/Icon/Spinner.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'

--- a/src/Icon/__tests__/Spinner-test.js
+++ b/src/Icon/__tests__/Spinner-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 import Spinner from '../Spinner'
 

--- a/src/Icon/__tests__/index-test.js
+++ b/src/Icon/__tests__/index-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 import Icon from '../index'
 import icons from '../icons'

--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import PropTypes from 'prop-types'
 
 import Default from './Default'

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 

--- a/src/Modal/Dialog.js
+++ b/src/Modal/Dialog.js
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { Component, createElement } from 'react'
+import React, { Component, createElement } from 'react'
 import PropTypes from 'prop-types'
 
 import Icon from '../Icon'

--- a/src/Modal/Prompt.js
+++ b/src/Modal/Prompt.js
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 export default class Prompt extends Component {

--- a/src/Modal/__tests__/Dialog-test.js
+++ b/src/Modal/__tests__/Dialog-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 import Dialog from '../Dialog'
 

--- a/src/Modal/__tests__/Prompt-test.js
+++ b/src/Modal/__tests__/Prompt-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 import Prompt from '../Prompt'
 

--- a/src/Modal/__tests__/index-test.js
+++ b/src/Modal/__tests__/index-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 import Modal from '../index'
 

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Portal from 'react-portal'
 

--- a/src/Notification/NotifyMesssage.js
+++ b/src/Notification/NotifyMesssage.js
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 

--- a/src/Notification/__tests__/NotifyMessage-test.js
+++ b/src/Notification/__tests__/NotifyMessage-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 
 import NotifyMesssage from '../NotifyMesssage'

--- a/src/Notification/__tests__/index-test.js
+++ b/src/Notification/__tests__/index-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 
 import Notification from '../index'

--- a/src/Notification/index.js
+++ b/src/Notification/index.js
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Portal from 'react-portal'
 import cx from 'classnames'

--- a/src/__tests__/Button-test.js
+++ b/src/__tests__/Button-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 import Button from '../Button'
 

--- a/src/__tests__/Dropdown-test.js
+++ b/src/__tests__/Dropdown-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 import cx from 'classnames'
 import Dropdown from '../Dropdown'

--- a/src/__tests__/Input-test.js
+++ b/src/__tests__/Input-test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
 
 import Input from '../Input'

--- a/src/stories/Button.js
+++ b/src/stories/Button.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { storiesOf, action } from '@storybook/react'
 import { Button, Icon } from '..'
 

--- a/src/stories/Dropdown.js
+++ b/src/stories/Dropdown.js
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/react'
 import cx from 'classnames'
-import { Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 import { Button, Dropdown } from '..'

--- a/src/stories/Icon.js
+++ b/src/stories/Icon.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Icon } from '..'
 

--- a/src/stories/Input.js
+++ b/src/stories/Input.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Input } from '..'
 

--- a/src/stories/Modal.js
+++ b/src/stories/Modal.js
@@ -1,5 +1,5 @@
 import { storiesOf, action } from '@storybook/react'
-import { Component } from 'react'
+import React, { Component } from 'react'
 import { Button, Modal } from '..'
 
 Modal.displayName = 'Modal'

--- a/src/stories/Notification.js
+++ b/src/stories/Notification.js
@@ -1,5 +1,5 @@
 import { storiesOf, action } from '@storybook/react'
-import { PureComponent } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { Notification, Button } from '..'
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,3 @@
-global.React = require('react')
-
 // eslint-disable-next-line no-console
 const error = console.error
 // eslint-disable-next-line no-console


### PR DESCRIPTION
In use cases like SSR it's not reasonable to do elaborate workarounds to the fact that uikit-react don't import React in jsx files.